### PR TITLE
Plausible Analytics Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,33 @@ impacting other functionality.
 
 ## JavaScript Requirements
 
+### Syntax Highlighting
+
 Syntax highlighting from `prism.js` can be customized and switched to a CDN provider if preferred by following 
 [these](https://prismjs.com/index.html#basic-usage-cdn) instructions
+
+### Analytics
+
+Support for [Plausible Analytics](https://github.com/plausible) is provided by enabling it within `_config.yml`.
+
+Example configuration: 
+
+``` 
+analytics:
+  plausible:
+    enabled: true
+    site_fqdn: 'lightspeed.tajacks.com'
+    script_source: 'https://plausible.io/js/script.js'
+```
+
+`enabled` - Boolean - To enable or disable page-view analytics.
+
+`site_fqdn` - String - The FQDN of your website to report back to Plausible.
+
+`script_source` - String - The source of the analytics script. Provided as a variable to accommodate self-hosted instances 
+of plausible.
+
+Support for more analytics platforms is a welcome suggestion, as long as they respect user privacy.
 
 ## Acknowledgements
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,17 @@ timezone_short: ET
 # Keywords
 keywords: ['seo', 'key', 'words']
 
+# Analytics (Plausible requires sign-up)
+analytics:
+  plausible:
+    enabled: false
+    site_fqdn: 'your.site.fqdn'
+    script_source: 'https://plausible.io/js/script.js'
+
 # Styling
 sass:
   sass_dir: _sass
-  style: expanded # compressed, compact, expanded or compressed
+  style: expanded # compact, expanded or compressed
 
 # Paginate
 pagination:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,3 +10,6 @@
 <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/styles.css" />
 <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/prism.css" />
 <script src="{{ site.baseurl }}/assets/js/prism.js"></script>
+{% if site.analytics.plausible.enabled  %}
+<script defer data-domain="{{ site.analytics.plausible.site_fqdn }}" src="{{ site.analytics.plausible.script_source }}"></script>
+{% endif %}


### PR DESCRIPTION
Added support for Plausible Analytics page view logging. Requires a Plausible analytics account, or, self-hosted instance. 